### PR TITLE
gsutil: download batch in bulk or all at once

### DIFF
--- a/project/gcloud/submit-training.sh
+++ b/project/gcloud/submit-training.sh
@@ -19,7 +19,6 @@ BUCKET="gs://secret-compass-237117-mlengine-us-west-1"
 
 echo "Submitting $JOB_NAME"
 
-exit 1
 gcloud ai-platform jobs submit training $JOB_NAME \
 	--staging-bucket $BUCKET \
         --package-path trainer \

--- a/project/trainer/cloud-config.py
+++ b/project/trainer/cloud-config.py
@@ -27,13 +27,13 @@ epochs_per_dataset = 1
 bucket = 'secret-compass-237117-mlengine-us-west-1'
 
 # path to provided foreground images
-fg_path = 'gs://%s/data/fg/' % bucket
+fg_base_path = 'gs://%s/data/fg/' % bucket
 
 # path to provided alpha mattes
-a_path = 'gs://%s/data/mask/' % bucket
+a_base_path = 'gs://%s/data/mask/' % bucket
 
 # Path to background images (MSCOCO)
-bg_path = 'gs://%s/data/bg/' % bucket
+bg_base_path = 'gs://%s/data/bg/' % bucket
 
 # Path to folder where you want the composited images to go
 out_path = 'data/merged/'

--- a/project/trainer/config.py
+++ b/project/trainer/config.py
@@ -16,6 +16,8 @@ epsilon = 1e-6
 epsilon_sqr = epsilon ** 2
 skip_crop = False
 add_noise = True
+pre_download  = True # Could reduce total download time at the expense of downloading everything upfront
+cache_dir = 'cache'
 
 reuse_backgrounds = True
 composite_backgrounds = True
@@ -27,41 +29,41 @@ epochs_per_dataset = 15 # should generally be 1
 env = 'remote' #'local' or 'remote'
 #************
 
+bucket = 'secret-compass-237117-mlengine-us-west-1'
+
 if env == 'remote':
 
-	bucket = 'secret-compass-237117-mlengine-us-west-1'
-	# path to provided foreground images
-	fg_base_path = 'gs://%s/all_data/fg/' % bucket 
-	# path to provided alpha mattes
-	a_base_path = 'gs://%s/all_data/mask/' % bucket
-	# Path to background images (MSCOCO)
-	bg_base_path = 'gs://%s/all_data/bg/' % bucket
-	# Path to folder where you want the composited images to go
-	out_path = 'data/merged/'
-	train_names_path = 'gs://%s/all_data/ten_bgs/train_names.txt' % bucket
-	valid_names_path = 'gs://%s/all_data/ten_bgs/valid_names.txt' % bucket
-	vgg16_weights_remote_path = 'gs://%s/models/vgg16_weights_tf_dim_ordering_tf_kernels.h5' % bucket
-	vgg16_weights_local_path = './cache/vgg16_weights_tf_dim_ordering_tf_kernels.h5'
-	fg_names_path = 'gs://%s/all_data/ten_bgs/fg_names.txt' % bucket
-	bg_names_path = 'gs://%s/all_data/ten_bgs/bg_names.txt' % bucket 
-	#checkpoint_models_path = 'gs://%s/models/checkpoints' % bucket
+    data_base_path = 'gs://%s/all_data/' % bucket 
+
+    # Path to folder where you want the composited images to go
+    out_path = 'data/merged/'
+    train_names_path = 'gs://%s/all_data/ten_bgs/train_names.txt' % bucket
+    valid_names_path = 'gs://%s/all_data/ten_bgs/valid_names.txt' % bucket
+    vgg16_weights_remote_path = 'gs://%s/models/vgg16_weights_tf_dim_ordering_tf_kernels.h5' % bucket
+    vgg16_weights_local_path = './%s/vgg16_weights_tf_dim_ordering_tf_kernels.h5' % cache_dir
+    fg_names_path = 'gs://%s/all_data/ten_bgs/fg_names.txt' % bucket
+    bg_names_path = 'gs://%s/all_data/ten_bgs/bg_names.txt' % bucket 
+    #checkpoint_models_path = 'gs://%s/models/checkpoints' % bucket
 
 if env == 'local': 
 
-	bucket = 'secret-compass-237117-mlengine-us-west-1'
-	# path to provided foreground images
-	fg_base_path = '../all_data/fg/'
-	# path to provided alpha mattes
-	a_base_path = '../all_data/mask/'
-	# Path to background images (MSCOCO)
-	bg_base_path = '../all_data/bg/'
-	# Path to folder where you want the composited images to go
-	out_path = '../all_data/merged/'
-	train_names_path = '../all_data/train_names.txt'
-	valid_names_path = '../all_data/valid_names.txt'
-	vgg16_weights_remote_path = 'gs://%s/models/vgg16_weights_tf_dim_ordering_tf_kernels.h5' % bucket
-	vgg16_weights_local_path = '../models/vgg16_weights_tf_dim_ordering_tf_kernels.h5'
-	fg_names_path = '../all_data/fg_names.txt'
-	bg_names_path = '../all_data/bg_names.txt'
-	#checkpoint_models_path = '../models'
+    data_base_path = '../all_data/'
+
+    # Path to folder where you want the composited images to go
+    out_path = '../all_data/merged/'
+    train_names_path = '../all_data/train_names.txt'
+    valid_names_path = '../all_data/valid_names.txt'
+    vgg16_weights_remote_path = 'gs://%s/models/vgg16_weights_tf_dim_ordering_tf_kernels.h5' % bucket
+    vgg16_weights_local_path = '../models/vgg16_weights_tf_dim_ordering_tf_kernels.h5'
+    fg_names_path = '../all_data/fg_names.txt'
+    bg_names_path = '../all_data/bg_names.txt'
+    #checkpoint_models_path = '../models'
+
+# path to provided foreground images
+fg_base_path = data_base_path + 'fg/'
+# path to provided alpha mattes
+a_base_path = data_base_path + 'mask/'
+# Path to background images (MSCOCO)
+bg_base_path = data_base_path + 'bg/'
+
 

--- a/project/trainer/config.py
+++ b/project/trainer/config.py
@@ -11,16 +11,15 @@ num_samples = 50880
 num_train_samples = 40704
 num_valid_samples = 10176
 
-
 unknown_code = 128
 epsilon = 1e-6
 epsilon_sqr = epsilon ** 2
 skip_crop = False
+add_noise = True
 
 reuse_backgrounds = True
 composite_backgrounds = True
 loss_ratio = .5 #mix between alpha-loss and compositional-loss
-add_noise = False
 
 epochs_per_dataset = 15 # should generally be 1
 
@@ -32,11 +31,11 @@ if env == 'remote':
 
 	bucket = 'secret-compass-237117-mlengine-us-west-1'
 	# path to provided foreground images
-	fg_path = 'gs://%s/all_data/fg/' % bucket 
+	fg_base_path = 'gs://%s/all_data/fg/' % bucket 
 	# path to provided alpha mattes
-	a_path = 'gs://%s/all_data/mask/' % bucket
+	a_base_path = 'gs://%s/all_data/mask/' % bucket
 	# Path to background images (MSCOCO)
-	bg_path = 'gs://%s/all_data/bg/' % bucket
+	bg_base_path = 'gs://%s/all_data/bg/' % bucket
 	# Path to folder where you want the composited images to go
 	out_path = 'data/merged/'
 	train_names_path = 'gs://%s/all_data/ten_bgs/train_names.txt' % bucket
@@ -51,11 +50,11 @@ if env == 'local':
 
 	bucket = 'secret-compass-237117-mlengine-us-west-1'
 	# path to provided foreground images
-	fg_path = '../all_data/fg/'
+	fg_base_path = '../all_data/fg/'
 	# path to provided alpha mattes
-	a_path = '../all_data/mask/'
+	a_base_path = '../all_data/mask/'
 	# Path to background images (MSCOCO)
-	bg_path = '../all_data/bg/'
+	bg_base_path = '../all_data/bg/'
 	# Path to folder where you want the composited images to go
 	out_path = '../all_data/merged/'
 	train_names_path = '../all_data/train_names.txt'

--- a/project/trainer/config.py
+++ b/project/trainer/config.py
@@ -20,6 +20,7 @@ skip_crop = False
 reuse_backgrounds = True
 composite_backgrounds = True
 loss_ratio = .5 #mix between alpha-loss and compositional-loss
+add_noise = False
 
 epochs_per_dataset = 15 # should generally be 1
 

--- a/project/trainer/data_generator.py
+++ b/project/trainer/data_generator.py
@@ -13,6 +13,7 @@ import tensorflow as tf
 
 import trainer.config as config
 from trainer.config import fg_base_path, bg_base_path, a_base_path
+from trainer.config import cache_dir
 from trainer.config import train_names_path, valid_names_path
 from trainer.config import img_cols, img_rows, channel
 from trainer.config import unknown_code
@@ -159,9 +160,9 @@ class DataGenSequence(Sequence):
                           a_base_path + im_name,
                           bg_base_path + bg_name))
 
-        fg_cache_dir = os.path.join('cache', 'fg')
-        a_cache_dir = os.path.join('cache', 'a')
-        bg_cache_dir = os.path.join('cache', 'bg')
+        fg_cache_dir = os.path.join(cache_dir, 'fg')
+        a_cache_dir = os.path.join(cache_dir, 'a')
+        bg_cache_dir = os.path.join(cache_dir, 'bg')
 
         # Check whether they're cached
         is_cached = False

--- a/project/trainer/data_generator.py
+++ b/project/trainer/data_generator.py
@@ -3,7 +3,7 @@ import os
 import random
 from random import shuffle
 import gc
-from time import time
+from time import time, sleep
 from collections import defaultdict
 
 import cv2 as cv
@@ -178,7 +178,16 @@ class DataGenSequence(Sequence):
             paths_by_dir[bg_cache_dir].extend([p[2] for p in paths])
 
             # Cache the batch!
-            mio.batch_cache(paths_by_dir)
+            retry = 0
+            while True:
+                try:
+                    mio.batch_cache(paths_by_dir)
+                    break
+                except Exception as e:
+                    retry = retry + 1
+                    if retry >= 5:
+                        raise e
+                    sleep(1)
 
         # 2. Now process
         for i_batch in range(length):

--- a/project/trainer/local-config.py
+++ b/project/trainer/local-config.py
@@ -27,13 +27,13 @@ epochs_per_dataset = 1
 bucket = 'secret-compass-237117-mlengine-us-west-1'
 
 # path to provided foreground images
-fg_path = '../data/fg/'
+fg_base_path = '../data/fg/'
 
 # path to provided alpha mattes
-a_path = '../data/mask/'
+a_base_path = '../data/mask/'
 
 # Path to background images (MSCOCO)
-bg_path = '../data/bg/'
+bg_base_path = '../data/bg/'
 
 # Path to folder where you want the composited images to go
 out_path = '../data/merged/'

--- a/project/trainer/my_io.py
+++ b/project/trainer/my_io.py
@@ -38,6 +38,8 @@ def is_cached(url_str, cache_dir):
 
 def batch_cache(paths_by_cache_dir):
     for cache_dir, paths in paths_by_cache_dir.items():
+        if not os.path.isdir(cache_dir):
+            os.makedirs(cache_dir, exist_ok=True)
         process = subprocess.Popen(["gsutil", "-m", "cp", "-I", cache_dir],
                                   stdin=subprocess.PIPE,
                                   stdout=subprocess.PIPE,
@@ -45,7 +47,7 @@ def batch_cache(paths_by_cache_dir):
         process.stdin.write("\n".join(paths).encode('utf-8'))
         stdout, stderr = process.communicate()
         if process.returncode != 0:
-            raise Exception("Nonzero return code: %s\n. %s" % (child.returncode,
+            raise Exception("Nonzero return code: %s\n. %s" % (process.returncode,
                                                                stderr))
 
 def imread(url_str, flags=1, cache_dir=None):

--- a/project/trainer/my_io.py
+++ b/project/trainer/my_io.py
@@ -1,9 +1,11 @@
 from urllib.parse import urlparse
+import os
+import subprocess
+
 from google.cloud import storage
 import cv2 as cv
 import numpy as np
 from tensorflow.python.lib.io import file_io
-import os
 
 def is_gcloud(url_str):
     return urlparse(url_str).scheme == 'gs'
@@ -28,10 +30,28 @@ def __download_as_file(url_str, dest):
     #print("Downloaded '%s'" % dest)
     return
 
+def __cache_file_name(url_str, cache_dir):
+    return os.path.join(cache_dir, url_str.split('/')[-1])
+
+def is_cached(url_str, cache_dir):
+    return os.path.isfile(__cache_file_name(url_str, cache_dir))
+
+def batch_cache(paths_by_cache_dir):
+    for cache_dir, paths in paths_by_cache_dir.items():
+        process = subprocess.Popen(["gsutil", "-m", "cp", "-I", cache_dir],
+                                  stdin=subprocess.PIPE,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE)
+        process.stdin.write("\n".join(paths).encode('utf-8'))
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            raise Exception("Nonzero return code: %s\n. %s" % (child.returncode,
+                                                               stderr))
+
 def imread(url_str, flags=1, cache_dir=None):
     if is_gcloud(url_str):
         if cache_dir:
-            filename = os.path.join(cache_dir, url_str.split('/')[-1])
+            filename = __cache_file_name(url_str, cache_dir)
             if not os.path.isfile(filename):
                 os.makedirs(cache_dir, exist_ok=True)
                 __download_as_file(url_str, filename)

--- a/project/trainer/prepare_to_train.py
+++ b/project/trainer/prepare_to_train.py
@@ -1,12 +1,12 @@
 # Usage
 #
-# First, set fg/a/bg_path in config.py
+# First, set fg/a/bg_base_path in config.py
 # Then:
 #    python prepare_to_train.py
 
 import os
 import random
-from trainer.config import fg_path, a_path, bg_path
+from trainer.config import fg_base_path, a_base_path, bg_base_path
 from trainer.config import fg_names_path, bg_names_path
 from trainer.config import train_names_path, valid_names_path
 from trainer.config import num_bgs_per_fg, training_fraction
@@ -62,9 +62,9 @@ if __name__ == '__main__':
     def listdir(path):
         return [f for f in os.listdir(path) if not f.startswith('.')]
 
-    fg_files = listdir(fg_path)
-    bg_files = listdir(bg_path)
-    a_files = listdir(a_path)
+    fg_files = listdir(fg_base_path)
+    bg_files = listdir(bg_base_path)
+    a_files = listdir(a_base_path)
 
     # (0) Validate
     #

--- a/project/trainer/task.py
+++ b/project/trainer/task.py
@@ -140,6 +140,9 @@ if __name__ == '__main__':
     job_dir = args["job_dir"]
     stage = args["stage"]
 
+    sys_ret = os.system("gsutil cp -p gs://secret-compass-237117-mlengine/data/bg/100.jpg .")
+    print("sys_ret = %s" % sys_ret)
+
     # Callbacks
     tensor_board = keras.callbacks.TensorBoard(log_dir= job_dir + '/logs',
                                                histogram_freq=0,

--- a/project/trainer/task.py
+++ b/project/trainer/task.py
@@ -3,14 +3,14 @@ import math
 import os
 from urllib.parse import urlparse
 
-
 import keras
 import tensorflow as tf
 from keras.callbacks import EarlyStopping, ReduceLROnPlateau
 from keras.utils import multi_gpu_model
 
-from trainer.config import patience, batch_size, epochs, num_train_samples, num_valid_samples, skip_crop, add_noise epochs_per_dataset
+from trainer.config import patience, batch_size, epochs, num_train_samples, num_valid_samples, skip_crop, add_noise, epochs_per_dataset
 from trainer.data_generator import train_gen, valid_gen
+from trainer.config import data_base_path, cache_dir, pre_download
 from trainer.migrate import migrate_model
 from trainer.segnet import build_encoder_decoder, build_refinement
 from trainer.utils import overall_loss, get_available_cpus, get_available_gpus
@@ -193,6 +193,12 @@ if __name__ == '__main__':
     if batch_size > num_valid_samples: 
         print("Decreasing batch_size to %s to equal num_valid_samples" % num_valid_samples)
         batch_size = num_valid_samples
+
+    if pre_download:
+        print("Downloading EVERYTHING before training!")
+        return_code = os.system("gsutil -m cp -r %s %s" % (data_base_path, cache_dir))
+        if return_code != 0:
+            raise Exception("Nonzero return exit code: %s" % return_code)
 
     # Start Fine-tuning
     model.fit_generator(train_gen(),

--- a/project/trainer/task.py
+++ b/project/trainer/task.py
@@ -9,7 +9,7 @@ import tensorflow as tf
 from keras.callbacks import EarlyStopping, ReduceLROnPlateau
 from keras.utils import multi_gpu_model
 
-from trainer.config import patience, batch_size, epochs, num_train_samples, num_valid_samples, skip_crop, epochs_per_dataset
+from trainer.config import patience, batch_size, epochs, num_train_samples, num_valid_samples, skip_crop, add_noise epochs_per_dataset
 from trainer.data_generator import train_gen, valid_gen
 from trainer.migrate import migrate_model
 from trainer.segnet import build_encoder_decoder, build_refinement
@@ -140,9 +140,6 @@ if __name__ == '__main__':
     job_dir = args["job_dir"]
     stage = args["stage"]
 
-    sys_ret = os.system("gsutil cp -p gs://secret-compass-237117-mlengine/data/bg/100.jpg .")
-    print("sys_ret = %s" % sys_ret)
-
     # Callbacks
     tensor_board = keras.callbacks.TensorBoard(log_dir= job_dir + '/logs',
                                                histogram_freq=0,
@@ -187,7 +184,7 @@ if __name__ == '__main__':
     print("Running the '%s' stage" % stage)
     num_cpu = get_available_cpus()
     workers = int(round(num_cpu / 2))
-    print('epochs_per_dataset={}\nskip_crop={}\nnum_gpu={}\nnum_cpu={}\nworkers={}\ntrained_models_path={}.'.format(epochs_per_dataset,skip_crop, num_gpu, num_cpu, workers, model_names))
+    print('epochs_per_dataset={}\nadd_noise={}\nskip_crop={}\nnum_gpu={}\nnum_cpu={}\nworkers={}\ntrained_models_path={}.'.format(epochs_per_dataset,add_noise,skip_crop, num_gpu, num_cpu, workers, model_names))
 
 
     # Final callbacks


### PR DESCRIPTION
Per batch, there's three calls to `gsutil` (one for each of fg, a, bg).
That's because there are three different (cache) directories.
If they all have unique filenames, we can share the same cache directory and issue just a single call.

If `pre_download` is set, then download everything before training